### PR TITLE
handle cmake depends properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(evo_robot_base_interface)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(evo-mbed-tools REQUIRED)
 
 add_compile_options(-std=c++14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(evo_robot_base_interface)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+find_package(evo-mbed-tools REQUIRED)
+
 add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
@@ -27,7 +30,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
    INCLUDE_DIRS include
-   LIBRARIES evo_robot_base_interface ${EVO_MBED_LIB}
+   LIBRARIES evo_robot_base_interface
    CATKIN_DEPENDS evo_motor_shield_interface
 #  DEPENDS system_lib
 )
@@ -42,9 +45,6 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
 )
-
-## Find important EVO_MBED_LIB
-find_library(EVO_MBED_LIB libevo_mbed_tools.a)
 
 ## Declare a C++ library
  add_library(${PROJECT_NAME}
@@ -64,6 +64,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  evo-mbed-tools::evo-mbed-tools
 )
 
 ## Declare a C++ executable

--- a/cmake/Findevo-mbed-tools.cmake
+++ b/cmake/Findevo-mbed-tools.cmake
@@ -1,7 +1,7 @@
 include(FindPackageHandleStandardArgs)
 
-find_package(evo-mbed-tools NO_MODULE)
-if(DEFINED evo-mbed-tools_FOUND)
+find_package(evo-mbed-tools QUIET NO_MODULE)
+if(DEFINED evo-mbed-tools_FOUND AND evo-mbed-tools_FOUND)
 	find_package_handle_standard_args(evo-mbed-tools CONFIG_MODE)
 	return()
 endif()
@@ -11,11 +11,11 @@ find_path(EVO_MBED_TOOLS_INCLUDE NAMES evo_mbed
 	)
 
 if(DEFINED EVO_MBED_TOOLS_INCLUDE)
-	file(READ ${EVO_MBED_TOOLS_INCLUDE}/Version.h version_file)
+	file(READ "${EVO_MBED_TOOLS_INCLUDE}/evo_mbed/Version.h" version_file)
 
-	string(REGEX MATCH "EVO_MBED_TOOLS_VER\s+\"(\d\.\d\.\d)\"" _ ${version_file})
-	set(evo-mbed-tools_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL)
-	set(evo-mbed-tools_INCLUDE_DIR ${EVO_MBED_TOOLS_INCLUDE} CACHE INTERNAL)
+	string(REGEX MATCH "EVO_MBED_TOOLS_VER[ \t]*\"([0-9]+.[0-9]+.[0-9]+)\"" _ ${version_file})
+	set(evo-mbed-tools_VERSION "${CMAKE_MATCH_1}")
+	set(evo-mbed-tools_INCLUDE_DIR "${EVO_MBED_TOOLS_INCLUDE}")
 endif()
 
 find_library(LIBEVO_MBED_TOOLS NAMES
@@ -29,14 +29,16 @@ find_library(LIBEVO_MBED_TOOLS NAMES
 if(DEFINED LIBEVO_MBED_TOOLS AND NOT TARGET evo-mbed-tools::evo-mbed-tools)
 	add_library(evo-mbed-tools::evo-mbed-tools UNKNOWN IMPORTED)
 	set_target_properties(evo-mbed-tools::evo-mbed-tools PROPERTIES
-		IMPORTED_LOCATION ${LIBEVO_MBED_TOOLS}
+		IMPORTED_LOCATION "${LIBEVO_MBED_TOOLS}"
 		)
 
-	set(evo-mbed-tools_LIBRARY ${LIBEVO_MBED_TOOLS} CACHE INTERNAL)
+	set(evo-mbed-tools_LIBRARY "${LIBEVO_MBED_TOOLS}")
 endif()
 
 find_package_handle_standard_args(evo-mbed-tools
-	REQUIRED_VARS evo-mbed-tools_INCLUDE_DIR evo-mbed-tools_LIBRARY
+	REQUIRED_VARS 
+		evo-mbed-tools_LIBRARY 
+		evo-mbed-tools_INCLUDE_DIR
 	VERSION_VAR evo-mbed-tools_VERSION
 	)
 

--- a/cmake/Findevo-mbed-tools.cmake
+++ b/cmake/Findevo-mbed-tools.cmake
@@ -1,0 +1,47 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(evo-mbed-tools NO_MODULE)
+if(DEFINED evo-mbed-tools_FOUND)
+	find_package_handle_standard_args(evo-mbed-tools CONFIG_MODE)
+	return()
+endif()
+
+find_path(EVO_MBED_TOOLS_INCLUDE NAMES evo_mbed
+	PATHS /usr/include/evo_mbed
+	)
+
+if(DEFINED EVO_MBED_TOOLS_INCLUDE)
+	file(READ ${EVO_MBED_TOOLS_INCLUDE}/Version.h version_file)
+
+	string(REGEX MATCH "EVO_MBED_TOOLS_VER\s+\"(\d\.\d\.\d)\"" _ ${version_file})
+	set(evo-mbed-tools_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL)
+	set(evo-mbed-tools_INCLUDE_DIR ${EVO_MBED_TOOLS_INCLUDE} CACHE INTERNAL)
+endif()
+
+find_library(LIBEVO_MBED_TOOLS NAMES
+	evo-mbed-tools
+	libevo-mbed-tools
+	libevo-mbed-tools.so
+	libevo-mbed-tools.so.1
+	PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/libevo-mbed-tools.so.1
+	)
+
+if(DEFINED LIBEVO_MBED_TOOLS AND NOT TARGET evo-mbed-tools::evo-mbed-tools)
+	add_library(evo-mbed-tools::evo-mbed-tools UNKNOWN IMPORTED)
+	set_target_properties(evo-mbed-tools::evo-mbed-tools PROPERTIES
+		IMPORTED_LOCATION ${LIBEVO_MBED_TOOLS}
+		)
+
+	set(evo-mbed-tools_LIBRARY ${LIBEVO_MBED_TOOLS} CACHE INTERNAL)
+endif()
+
+find_package_handle_standard_args(evo-mbed-tools
+	REQUIRED_VARS evo-mbed-tools_INCLUDE_DIR evo-mbed-tools_LIBRARY
+	VERSION_VAR evo-mbed-tools_VERSION
+	)
+
+mark_as_advanced(evo-mbed-tools_INCLUDE_DIR
+	evo-mbed-tools_LIBRARY
+	evo-mbed-tools_VERSION
+	)
+


### PR DESCRIPTION
Handle CMake dependency resolution correctly and backwards compatible to none-config libevo-mbed-tools build